### PR TITLE
Fix: fix video still playing after exit room

### DIFF
--- a/lib/modules/live_play/live_play_controller.dart
+++ b/lib/modules/live_play/live_play_controller.dart
@@ -45,6 +45,10 @@ class LivePlayController extends GetxController {
       // add delay to avoid hero animation lag
       int delay = (Platform.isWindows || Platform.isLinux) ? 500 : 0;
       Timer(Duration(milliseconds: delay), () {
+        // if controller is closed, should abort
+        if (isClosed) {
+          return;
+        }
         videoController = VideoController(
           playerKey: playerKey,
           room: room,


### PR DESCRIPTION
if exit the room after enter the room immediately. The live stream will still playing even room is exited.
Fix this by adding checking if controller is closed.